### PR TITLE
Fix Undefined Attack Ratings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.2.0] - TBD
+## [2.2.1] - 2024-09-15
+
+### Fixed
+
+-   fixed undefined attack ratings creating error logs
+
+## [2.2.0] - 2024-09-15
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "erdtree",
-    "version": "2.2.0",
+    "version": "2.2.1",
     "private": true,
     "scripts": {
         "dev": "next dev",

--- a/src/app/weapons/WeaponResultRow.tsx
+++ b/src/app/weapons/WeaponResultRow.tsx
@@ -18,6 +18,22 @@ const INFUSION_IDS: string[] = [
     "occult",
 ];
 
+const DEFAULT_INFUSION_MAP: InfusionMap<number> = {
+    standard: 0,
+    heavy: 0,
+    keen: 0,
+    quality: 0,
+    fire: 0,
+    "flame-art": 0,
+    lightning: 0,
+    sacred: 0,
+    magic: 0,
+    cold: 0,
+    poison: 0,
+    blood: 0,
+    occult: 0,
+};
+
 export function WeaponResultRow(props: {
     weaponName: string;
     attackRatings: InfusionMap<number>;
@@ -44,9 +60,9 @@ export function WeaponResultRow(props: {
             {INFUSION_IDS.map((infId) => (
                 <TableDataWithHover
                     key={infId}
-                    attackRating={props.attackRatings[infId]!}
-                    max={props.max}
-                    data={props.arBreakdown[infId]!}
+                    attackRating={props.attackRatings[infId]! ?? 0}
+                    max={props.max ?? 0}
+                    data={props.arBreakdown[infId]! ?? DEFAULT_INFUSION_MAP}
                     style={
                         props.attackRatings[infId] == props.max &&
                         props.attackRatings[infId] != undefined


### PR DESCRIPTION
When infusions are filtered out, the empty cells left behind create errors in the console upon hover-over. This PR fixes that.